### PR TITLE
Convert template images to RGBA on load

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   api:
     environment:


### PR DESCRIPTION
To account for cases where an image template uses an indexed colour palette, which prevents colours outside of the palette from being used, and causes aliasing of fonts. Converting to a common colour mode before further processing allows the app to accept a wider range of image template formats.